### PR TITLE
Fix default value when getting from param dict in getMag

### DIFF
--- a/BaseImage.py
+++ b/BaseImage.py
@@ -29,7 +29,7 @@ def getMag(s, params):
             mag == "NA"):  # openslide doesn't set objective-power for all SVS files: https://github.com/openslide/openslide/issues/247
         mag = osh.properties.get("aperio.AppMag", "NA")
     if (mag == "NA" or strtobool(
-            params.get("confirm_base_mag", False))):
+            params.get("confirm_base_mag", "False"))):
         # do analysis work here
         logging.warning(f"{s['filename']} - Unknown base magnification for file")
         s["warnings"].append(f"{s['filename']} - Unknown base magnification for file")


### PR DESCRIPTION
Fix the default value when getting "confirm_base_mag" key from the params dict. Avoids error in strtobool function.