### PR TITLE
Create requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+openslide-python
+scikit-image
+scikit-learn
+numpy
+scipy
+matplotlib


### PR DESCRIPTION
This way it may be easier to recommend ```pip install -r requirements.txt``` instead of having user collect the python requirements themselves.