### PR TITLE
replace seperateStains with separateStains

### DIFF
--- a/histoqc/DeconvolutionModule.py
+++ b/histoqc/DeconvolutionModule.py
@@ -13,20 +13,20 @@ from distutils.util import strtobool
 import matplotlib.pyplot as plt
 
 
-def seperateStains(s, params):
-    logging.info(f"{s['filename']} - \tseperateStains")
+def separateStains(s, params):
+    logging.info(f"{s['filename']} - \tseparateStains")
     stain = params.get("stain", "")
     use_mask = strtobool(params.get("use_mask", "True"))
 
     if stain == "":
-        logging.error(f"{s['filename']} - stain not set in DeconvolutionModule.seperateStains")
+        logging.error(f"{s['filename']} - stain not set in DeconvolutionModule.separateStains")
         sys.exit(1)
         return
 
     stain_matrix = getattr(sys.modules[__name__], stain, "")
 
     if stain_matrix == "":
-        logging.error(f"{s['filename']} - Unknown stain matrix specified in DeconolutionModule.seperateStains")
+        logging.error(f"{s['filename']} - Unknown stain matrix specified in DeconolutionModule.separateStains")
         sys.exit(1)
         return
 
@@ -38,9 +38,9 @@ def seperateStains(s, params):
             s.addToPrintList(f"deconv_c{c}_mean", str(-100))
             io.imsave(s["outdir"] + os.sep + s["filename"] + f"_deconv_c{c}.png", img_as_ubyte(np.zeros(mask.shape)))
 
-        logging.warning(f"{s['filename']} - DeconvolutionModule.seperateStains: NO tissue "
+        logging.warning(f"{s['filename']} - DeconvolutionModule.separateStains: NO tissue "
                              f"remains detectable! Saving Black images")
-        s["warnings"].append(f"DeconvolutionModule.seperateStains: NO tissue "
+        s["warnings"].append(f"DeconvolutionModule.separateStains: NO tissue "
                              f"remains detectable! Saving Black images")
 
         return

--- a/histoqc/config/config.ini
+++ b/histoqc/config/config.ini
@@ -17,7 +17,7 @@ steps= BasicModule.getBasicStats
     BrightContrastModule.getBrightnessGray
     BrightContrastModule.getBrightnessByChannelinColorSpace:RGB
     BrightContrastModule.getBrightnessByChannelinColorSpace:YUV
-    DeconvolutionModule.seperateStains
+    DeconvolutionModule.separateStains
     SaveModule.saveFinalMask
     SaveModule.saveThumbnails
     BasicModule.finalComputations
@@ -172,7 +172,7 @@ disk_radius: 5
 #area_threshold: 90000
 area_threshold:  10000
 
-[DeconvolutionModule.seperateStains]
+[DeconvolutionModule.separateStains]
 ;hed_from_rgb: Hematoxylin + Eosin + DAB
 ;hdx_from_rgb: Hematoxylin + DAB
 ;fgx_from_rgb: Feulgen + Light Green

--- a/histoqc/config/config_clinical.ini
+++ b/histoqc/config/config_clinical.ini
@@ -17,7 +17,7 @@ steps= BasicModule.getBasicStats
     BrightContrastModule.getBrightnessGray
     BrightContrastModule.getBrightnessByChannelinColorSpace:RGB
     BrightContrastModule.getBrightnessByChannelinColorSpace:YUV
-    DeconvolutionModule.seperateStains
+    DeconvolutionModule.separateStains
     SaveModule.saveFinalMask
     SaveModule.saveThumbnails
     BasicModule.finalComputations
@@ -172,7 +172,7 @@ disk_radius: 5
 #area_threshold: 90000
 area_threshold:  10000
 
-[DeconvolutionModule.seperateStains]
+[DeconvolutionModule.separateStains]
 ;hed_from_rgb: Hematoxylin + Eosin + DAB
 ;hdx_from_rgb: Hematoxylin + DAB
 ;fgx_from_rgb: Feulgen + Light Green

--- a/histoqc/config/config_ihc.ini
+++ b/histoqc/config/config_ihc.ini
@@ -16,7 +16,7 @@ steps= BasicModule.getBasicStats
     BrightContrastModule.getBrightnessGray
     BrightContrastModule.getBrightnessByChannelinColorSpace:RGB
     BrightContrastModule.getBrightnessByChannelinColorSpace:YUV
-    DeconvolutionModule.seperateStains
+    DeconvolutionModule.separateStains
     HistogramModule.getHistogram
     SaveModule.saveFinalMask
     SaveModule.saveThumbnails
@@ -193,7 +193,7 @@ disk_radius: 5
 #area_threshold: 90000
 area_threshold:  10000
 
-[DeconvolutionModule.seperateStains]
+[DeconvolutionModule.separateStains]
 ;hed_from_rgb: Hematoxylin + Eosin + DAB
 ;hdx_from_rgb: Hematoxylin + DAB
 ;fgx_from_rgb: Feulgen + Light Green

--- a/histoqc/config/config_light.ini
+++ b/histoqc/config/config_light.ini
@@ -16,7 +16,7 @@ steps= BasicModule.getBasicStats
 ;    BrightContrastModule.getBrightnessGray
 ;    BrightContrastModule.getBrightnessByChannelinColorSpace:RGB
 ;    BrightContrastModule.getBrightnessByChannelinColorSpace:YUV
-;    DeconvolutionModule.seperateStains
+;    DeconvolutionModule.separateStains
     SaveModule.saveFinalMask
     SaveModule.saveThumbnails
     BasicModule.finalComputations
@@ -164,7 +164,7 @@ disk_radius: 7
 [BasicModule.finalProcessingArea]
 area_threshold: 90000
 
-[DeconvolutionModule.seperateStains]
+[DeconvolutionModule.separateStains]
 ;hed_from_rgb: Hematoxylin + Eosin + DAB
 ;hdx_from_rgb: Hematoxylin + DAB
 ;fgx_from_rgb: Feulgen + Light Green

--- a/histoqc/config/config_v2.1.ini
+++ b/histoqc/config/config_v2.1.ini
@@ -23,7 +23,7 @@ steps= BasicModule.getBasicStats
     BrightContrastModule.getBrightnessGray
     BrightContrastModule.getBrightnessByChannelinColorSpace:RGB
     BrightContrastModule.getBrightnessByChannelinColorSpace:YUV
-    DeconvolutionModule.seperateStains
+    DeconvolutionModule.separateStains
     SaveModule.saveFinalMask
     SaveModule.saveThumbnails
     BasicModule.finalComputations
@@ -203,7 +203,7 @@ disk_radius: 5
 #area_threshold: 90000
 area_threshold:  10000
 
-[DeconvolutionModule.seperateStains]
+[DeconvolutionModule.separateStains]
 ;hed_from_rgb: Hematoxylin + Eosin + DAB
 ;hdx_from_rgb: Hematoxylin + DAB
 ;fgx_from_rgb: Feulgen + Light Green


### PR DESCRIPTION
This commit fixes a typo. This was done using the command

```
find ./ -type f -exec sed -i 's/seperateStains/separateStains/g' {} \;
```

in the root directory of the project.

Fixes https://github.com/choosehappy/HistoQC/issues/194