### PR TITLE
use multi-stage build in Dockerfile to halve size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ COPY . .
 # installation into the second stage of the build.
 ENV PATH="/opt/HistoQC/venv/bin:$PATH"
 RUN python -m venv venv \
+    && python -m pip install --no-cache-dir setuptools wheel \
     && python -m pip install --no-cache-dir -r requirements.txt \
     && python -m pip install --no-cache-dir . \
     # We force this so there is no error even if the dll does not exist.
@@ -20,13 +21,13 @@ RUN python -m venv venv \
 
 FROM python:3.8-slim
 ARG DEBIAN_FRONTEND=noninteractive
-WORKDIR /opt/HistoQC
-COPY --from=builder /opt/HistoQC/ .
-ENV PATH="/opt/HistoQC/venv/bin:$PATH"
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         libopenslide0 \
         libtk8.6 \
     && rm -rf /var/lib/apt/lists/*
+WORKDIR /opt/HistoQC
+COPY --from=builder /opt/HistoQC/ .
+ENV PATH="/opt/HistoQC/venv/bin:$PATH"
 
 WORKDIR /data

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,20 +26,7 @@ ENV PATH="/opt/HistoQC/venv/bin:$PATH"
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         libopenslide0 \
+        libtk8.6 \
     && rm -rf /var/lib/apt/lists/*
 
-# uncomment:
-    # 1 - this additional RUN only if you are facing issues with UTF8 when running your container
-    # 2 - all ENV variables in comment
-
-    #RUN apt-get update -y \
-    #    && apt-get install --reinstall -y locales \
-    #    # uncomment chosen locale to enable it's generation
-    #    && sed -i 's/# pl_PL.UTF-8 UTF-8/pl_PL.UTF-8 UTF-8/' /etc/locale.gen \
-    #    # generate chosen locale
-    #    && locale-gen pl_PL.UTF-8
-
-    ## set system-wide locale settings
-    #ENV LANG pl_PL.UTF-8
-    #ENV LANGUAGE pl_PL
-    #ENV LC_ALL pl_PL.UTF-8
+WORKDIR /data


### PR DESCRIPTION
This commit proposes using a multi-stage Dockerfile. In the first stage,
we use the official python:3.8 image, which includes a C compilers. We
install the project and its dependencies. We create a dedicated virtual
environment for the project. Then in the second stage, we copy over the
project files and the python virtual environment, and we install
libopenslide0, which is required for openslide-python runtime.

This results in a more complex Dockerfile, but the resulting image is
half as big as the original (671 MB from about 1.3GB). I am also happy
to maintain this Dockerfile and answer any questions about it.