### PR TITLE
add expanduser in basepath and outdir

### DIFF
--- a/histoqc/__main__.py
+++ b/histoqc/__main__.py
@@ -95,7 +95,7 @@ def main(argv=None):
             return -1
 
     # --- create output directory and move log --------------------------------
-
+    args.outdir = os.path.expanduser(args.outdir)
     os.makedirs(args.outdir, exist_ok=True)
     move_logging_file_handler(logging.getLogger(), args.outdir)
 
@@ -119,7 +119,7 @@ def main(argv=None):
     results.add_header(f"command_line_args:\t{' '.join(argv)}")
 
     # --- receive input file list (there are 3 options) -----------------------
-
+    args.basepath = os.path.expanduser(args.basepath)
     if len(args.input_pattern) > 1:
         # more than one input_pattern is interpreted as a list of files
         # (basepath is ignored)


### PR DESCRIPTION
Closes https://github.com/choosehappy/HistoQC/issues/197

When using a path with a tilde `~` on unix-like systems, the path is
interpreted as a literal `./~`, meaning a directory named `~` in the
current working directory. Users typically do not want this and would
probably be surprised by this behavior. I know I was surprised when I
ran histoqc and then saw a new directory named `~`. I removed it very
carefully, trying to be sure I didn't trash my home directory :)

This commit fixes the issue by expanding the tilde into the path to the
home directory. If a path does not begin with a tilde, the path is
unchanged.