### PR TITLE
remove Python::3.6 classifier

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,6 @@ classifiers =
     License :: OSI Approved :: BSD License
     Programming Language :: Python
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9


### PR DESCRIPTION
This removes `Programming Language :: Python :: 3.6` from the classifiers, because according to `python_requires`, histoqc requires at least python 3.7.