### PR TITLE
bounding_box and best level for downsample

### DIFF
--- a/histoqc/BaseImage.py
+++ b/histoqc/BaseImage.py
@@ -4,6 +4,7 @@ import numpy as np
 import inspect
 import zlib, dill
 from distutils.util import strtobool
+from PIL import Image
 
 #os.environ['PATH'] = 'C:\\research\\openslide\\bin' + ';' + os.environ['PATH'] #can either specify openslide bin path in PATH, or add it dynamically
 import openslide
@@ -61,7 +62,16 @@ class BaseImage(dict):
         self["dir"] = os.path.dirname(fname)
 
         self["os_handle"] = openslide.OpenSlide(fname)
-        self["image_base_size"] = self["os_handle"].dimensions
+        self["bounding_box"] = strtobool(params.get("bounding_box",'False'))
+        if self["bounding_box"] == True:
+            try:
+                self["image_base_size"] = (int(self["os_handle"].properties.get(openslide.PROPERTY_NAME_BOUNDS_WIDTH,'NA')),
+                                           int(self["os_handle"].properties.get(openslide.PROPERTY_NAME_BOUNDS_HEIGHT,'NA')))
+            except:
+                logging.error(f"{self['filename']}: could not read the size of the bounding box")
+                exit()
+        else:
+            self["image_base_size"] = self["os_handle"].dimensions
         self["image_work_size"] = params.get("image_work_size", "1.25x")
         self["mask_statistics"] = params.get("mask_statistics", "relative2mask")
         self["base_mag"] = getMag(self, params)
@@ -98,11 +108,30 @@ class BaseImage(dict):
         key = "img_" + str(dim)
         if key not in self:
             osh = self["os_handle"]
+            xc=yc=0
+            if self["bounding_box"] == True:
+                try:
+                    xc=int(osh.properties.get(openslide.PROPERTY_NAME_BOUNDS_X,'NA'))
+                    yc=int(osh.properties.get(openslide.PROPERTY_NAME_BOUNDS_Y,'NA'))
+                except:
+                    logging.error(f"{self['filename']}: could not find bounding box coordinates")
+                    return -1
             if dim.replace(".", "0", 1).isdigit(): #check to see if dim is a number
                 dim = float(dim)
                 if dim < 1 and not dim.is_integer():  # specifying a downscale factor from base
                     new_dim = np.asarray(osh.dimensions) * dim
-                    self[key] = np.array(osh.get_thumbnail(new_dim))
+                    if self["bounding_box"] == True:
+                        downsample = max(*(dim / thumb for dim, thumb in zip(osh.dimensions, new_dim)))
+                        level = osh.get_best_level_for_downsample(downsample)
+                        size=tuple((np.array(self["image_base_size"])/osh.level_downsamples[level]).astype(int))
+                        tile = osh.read_region((xc, yc), level, size)
+                        bg_color = '#' + osh.properties.get(openslide.PROPERTY_NAME_BACKGROUND_COLOR, 'ffffff')
+                        thumb = Image.new('RGB', tile.size, bg_color)
+                        thumb.paste(tile, None, tile)
+                        thumb.thumbnail(size, getattr(Image, 'Resampling', Image).LANCZOS)
+                        self[key] = np.array(thumb)
+                    else:
+                        self[key] = np.array(osh.get_thumbnail(new_dim))
                 elif dim < 100:  # assume it is a level in the openslide pyramid instead of a direct request
                     dim = int(dim)
                     if dim >= osh.level_count:
@@ -112,14 +141,36 @@ class BaseImage(dict):
                             f"{self['filename']}: Desired Image Level {dim+1} does not exist! Instead using level {osh.level_count-1}! Downstream output may not be correct")
                         self["warnings"].append(
                             f"Desired Image Level {dim+1} does not exist! Instead using level {osh.level_count-1}! Downstream output may not be correct")
+                    if self["bounding_box"] == True:
+                        size=tuple((np.array(self["image_base_size"])/osh.level_downsamples[dim]).astype(int))
+                    else:
+                        size=osh.level_downsamples[dim]
                     logging.info(
                         f"{self['filename']} - \t\tloading image from level {dim} of size {osh.level_dimensions[dim]}")
-                    img = osh.read_region((0, 0), dim, osh.level_dimensions[dim])
-                    self[key] = np.asarray(img)[:, :, 0:3]
+                    tile = osh.read_region((xc, yc), dim, size)
+                    if np.shape(tile)[-1]==4:
+                        bg_color = '#' + osh.properties.get(openslide.PROPERTY_NAME_BACKGROUND_COLOR, 'ffffff')
+                        img = Image.new('RGB', size, bg_color)
+                        img.paste(tile, None, tile)
+                    else:
+                        img=tile
+                    img = np.asarray(img)
+                    self[key] = img
                 else:  # assume its an explicit size, *WARNING* this will likely cause different images to have different
                     # perceived magnifications!
                     logging.info(f"{self['filename']} - \t\tcreating image thumb of size {str(dim)}")
-                    self[key] = np.array(osh.get_thumbnail((dim, dim)))
+                    if self["bounding_box"] == True:
+                        downsample = max(*(dim / thumb for dim, thumb in zip(osh.dimensions, (dim, dim))))
+                        level = osh.get_best_level_for_downsample(downsample)
+                        size=tuple((np.array(self["image_base_size"])/osh.level_downsamples[level]).astype(int))
+                        tile = osh.read_region((xc, yc), level, size)
+                        bg_color = '#' + osh.properties.get(openslide.PROPERTY_NAME_BACKGROUND_COLOR, 'ffffff')
+                        thumb = Image.new('RGB', tile.size, bg_color)
+                        thumb.paste(tile, None, tile)
+                        thumb.thumbnail(size, getattr(Image, 'Resampling', Image).LANCZOS)
+                        self[key] = np.array(thumb)
+                    else:
+                        self[key] = np.array(osh.get_thumbnail((dim, dim)))
             elif "X" in dim.upper():  # specifies a desired operating magnification
 
                 base_mag = self["base_mag"]
@@ -133,23 +184,43 @@ class BaseImage(dict):
                 target_mag = float(dim.upper().split("X")[0])
 
                 down_factor = base_mag / target_mag
-                level = osh.get_best_level_for_downsample(down_factor)
+                relative_down_factors_idx=[np.isclose(i/down_factor,1,atol=.01) for i in osh.level_downsamples]
+                level=np.where(relative_down_factors_idx)[0]
+                if level.size:
+                    level=level[0]
+                else:
+                    level = osh.get_best_level_for_downsample(down_factor)
+                
                 relative_down = down_factor / osh.level_downsamples[level]
+                if self["bounding_box"] == True:
+                    size=tuple((np.array(self["image_base_size"])/osh.level_downsamples[level]).astype(int))
+                else:
+                    size=osh.level_dimensions[level]
                 if relative_down == 1.0: #there exists an open slide level exactly for this requested mag
-                    output = osh.read_region((0, 0), level, osh.level_dimensions[level])
-                    output = np.asarray(output)[:, :, 0:3]
+                    output = osh.read_region((xc, yc), level, size)
+                    if np.shape(output)[-1]==4:
+                        bg_color = '#' + osh.properties.get(openslide.PROPERTY_NAME_BACKGROUND_COLOR, 'ffffff')
+                        img = Image.new('RGB', size, bg_color)
+                        img.paste(output, None, output)
+                        output=img
+                    output = np.asarray(output)
                 else: #there does not exist an openslide level for this mag, need to create ony dynamically
                     win_size = 2048
                     win_size_down = int(win_size * 1 / relative_down)
-                    dim_base = osh.level_dimensions[0]
+                    dim_base = self["image_base_size"]
                     output = []
-                    for x in range(0, dim_base[0], round(win_size * osh.level_downsamples[level])):
+                    for x in range(xc, dim_base[0], round(win_size * osh.level_downsamples[level])):
                         row_piece = []
-                        for y in range(0, dim_base[1], round(win_size * osh.level_downsamples[level])):
+                        for y in range(yc, dim_base[1], round(win_size * osh.level_downsamples[level])):
                             aa = osh.read_region((x, y), level, (win_size, win_size))
+                            if np.shape(aa)[-1]==4:
+                                bg_color = '#' + osh.properties.get(openslide.PROPERTY_NAME_BACKGROUND_COLOR, 'ffffff')
+                                img = Image.new('RGB', tuple((win_size, win_size)), bg_color)
+                                img.paste(aa, None, aa)
+                                aa=img
                             bb = aa.resize((win_size_down, win_size_down))
                             row_piece.append(bb)
-                        row_piece = np.concatenate(row_piece, axis=0)[:, :, 0:3]
+                        row_piece = np.concatenate(row_piece, axis=0)
                         output.append(row_piece)
 
                     output = np.concatenate(output, axis=1)

--- a/histoqc/config/config_first.ini
+++ b/histoqc/config/config_first.ini
@@ -17,6 +17,7 @@ steps= BasicModule.getBasicStats
 
 [BaseImage.BaseImage]
 image_work_size = 1.25x
+bounding_box: False
 
 #three options: relative2mask, absolute, relative2image
 mask_statistics = relative2mask


### PR DESCRIPTION
Merge alpha channel to avoid black background.
Add bounding_box option on config file to open WSI on the bounding box (default to False).
Find best level for downsample when factor isn't integer.