### PR TITLE
Add procps to Dockerfile to enable HistoQC on Nextflow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         libopenslide0 \
         libtk8.6 \
+        procps \
     && rm -rf /var/lib/apt/lists/*
 WORKDIR /opt/HistoQC
 COPY --from=builder /opt/HistoQC/ .


### PR DESCRIPTION
I would like to integrate HistoQC in a [Nextflow](https://nextflow.io/) pipeline to enable scalable and reproducible deployment across multiple compute infrastructures.

Nextflow requires `procps` to be avaliable within the Docker container in order to collect task metrics.
This PR adds it to the `Dockerfile`. If the Dockerhub image is able to be updated that would be appreciated.

This has been tested in a proof-of-concept workflow ([adamjtaylor/nf-histoqc](https://github.com/adamjtaylor/nf-histoqc)) with an [updated Docker image](https://hub.docker.com/repository/docker/adamjtaylor/histoqc/general) integrating the same proposed change.

Many thanks!