### PR TITLE
Save mask module #222

### DIFF
--- a/histoqc/SaveModule.py
+++ b/histoqc/SaveModule.py
@@ -67,7 +67,18 @@ def saveMacro(s, params):
     saveAssociatedImage(s, "macro", dim)
     return
     
+def saveMask(s, params):
+    logging.info(f"{s['filename']} - \tsaveMaskUse")
+    suffix = params.get("suffix", None)
+    
+    # check suffix param
+    if not suffix:
+        msg = f"{s['filename']} - \tPlease set the suffix for mask use."
+        logging.error(msg)
+        return
 
+    # save mask
+    io.imsave(f"{s['outdir']}{os.sep}{s['filename']}_{suffix}.png", img_as_ubyte(s["img_mask_use"]))
 
 def saveThumbnails(s, params):
     logging.info(f"{s['filename']} - \tsaveThumbnail")

--- a/histoqc/config/config_clinical.ini
+++ b/histoqc/config/config_clinical.ini
@@ -5,9 +5,11 @@ steps= BasicModule.getBasicStats
     LightDarkModule.getIntensityThresholdPercent:tissue
     LightDarkModule.getIntensityThresholdPercent:darktissue
     BubbleRegionByRegion.detectSmoothness
+    SaveModule.saveMask:first
     MorphologyModule.removeFatlikeTissue
     MorphologyModule.fillSmallHoles
     MorphologyModule.removeSmallObjects
+    SaveModule.saveMask:second
     BlurDetectionModule.identifyBlurryRegions
     BasicModule.finalProcessingSpur
     BasicModule.finalProcessingArea
@@ -17,6 +19,7 @@ steps= BasicModule.getBasicStats
     BrightContrastModule.getBrightnessGray
     BrightContrastModule.getBrightnessByChannelinColorSpace:RGB
     BrightContrastModule.getBrightnessByChannelinColorSpace:YUV
+    SaveModule.saveMask:third
     DeconvolutionModule.separateStains
     SaveModule.saveFinalMask
     SaveModule.saveMacro
@@ -196,3 +199,12 @@ use_mask: True
 threshold: .01
 kernel_size: 10
 min_object_size: 500
+
+[SaveModule.saveMask:first]
+suffix: first
+
+[SaveModule.saveMask:second]
+suffix: second
+
+[SaveModule.saveMask:third]
+suffix: third


### PR DESCRIPTION
add the saveMask function with suffix parameter and when pipeline hits the saveModule.saveMask, it will save the current "img_mask_use" as image with provided sufffix. the test config file on config_clinical.ini