### PR TITLE
correct Classification Module

### DIFF
--- a/histoqc/ClassificationModule.py
+++ b/histoqc/ClassificationModule.py
@@ -202,7 +202,12 @@ def byExampleWithFeatures(s, params):
     img = s.getImgThumb(s["image_work_size"])
     feats = compute_features(img, params)
     cal = clf.predict_proba(feats.reshape(-1, feats.shape[2]))
-    cal = cal.reshape(img.shape[0], img.shape[1], 2)
+
+    #account for difference in output array size
+    if name == "pen_markings":
+        cal = cal.reshape(img.shape[0], img.shape[1], 3)
+    else:
+        cal = cal.reshape(img.shape[0], img.shape[1], 2)
 
     mask = cal[:, :, 1] > thresh
 


### PR DESCRIPTION
When pen_markings is used, the model used generates an output feature array of length H x W x 3. The coverslip_edge model generates an array of length H x W x 2. This output asymetry leads to an error when the "ClassificationModule.byExample:pen_markings" element of the pipeline is used in the config file because the reshape function is hardcoded to take an array of H x W x 2.

This if statement takes into account the difference in shape based on the name of the active module.