### PR TITLE
Bump matplotlib to +3.6.0 to make it work on ARM devices

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ scikit-image~=0.19.2
 scikit-learn==0.24.1
 numpy~=1.20.3
 scipy==1.10.0
-matplotlib==3.3.4
+matplotlib==3.6.3
 dill==0.3.3
 pytest~=7.1.3
 importlib-resources


### PR DESCRIPTION
I encountered https://github.com/matplotlib/matplotlib/issues/24010/ while pip installing because a wheel wasn't built so my LLVM compiler printed `'error: 'shuffle' is not a member of 'std''`. The fix was merged in 3.7.0 with https://github.com/matplotlib/matplotlib/pull/24062 but the newest bump of 3.7.X is 3.7.2 so bump it there.

EDIT: I found out that 3.6.X works thanks to precompiled wheels, but this would not work on LLVM Windows ARM. Please let me know if you'd prefer 3.6.X earlier or 3.7.X later